### PR TITLE
avoid unnecessary recalculations of required height

### DIFF
--- a/addon/modifiers/autoresize.js
+++ b/addon/modifiers/autoresize.js
@@ -1,34 +1,47 @@
-import { modifier } from 'ember-modifier';
+import Modifier from 'ember-modifier';
+import { action } from '@ember/object';
+import { scheduleOnce } from '@ember/runloop';
 
-function resize(element) {
-  // height must be calculated independently from height previously enforced
-  element.style.height = 'auto';
+export default class AutoresizeModifier extends Modifier {
+  @action
+  resize() {
+    let { element } = this;
 
-  let isBorderBox = window.getComputedStyle(element).boxSizing === 'border-box';
-  let requiredHeight = element.scrollHeight;
+    // height must be calculated independently from height previously enforced
+    element.style.height = 'auto';
 
-  if (isBorderBox) {
-    // borders must be added on top of scrollHeight if box-sizing is border-box
-    let borderHeight = element.offsetHeight - element.clientHeight;
-    requiredHeight += borderHeight;
+    let isBorderBox = window.getComputedStyle(element).boxSizing === 'border-box';
+    let requiredHeight = element.scrollHeight;
+
+    if (isBorderBox) {
+      // borders must be added on top of scrollHeight if box-sizing is border-box
+      let borderHeight = element.offsetHeight - element.clientHeight;
+      requiredHeight += borderHeight;
+    }
+
+    element.style.height = `${requiredHeight}px`;
   }
 
-  element.style.height = `${requiredHeight}px`;
-}
+  @action
+  scheduleResize() {
+    scheduleOnce('afterRender', this, 'resize');
+  }
 
-function eventHandler(event) {
-  resize(event.target);
-}
+  didInstall() {
+    // resize for initial value
+    this.scheduleResize();
 
-export default modifier(function autoresize(element) {
-  // resize for initial value
-  resize(element);
+    // resize on every input event
+    this.element.addEventListener('input', this.scheduleResize);
+  }
 
-  // resize on every input event
-  element.addEventListener('input', eventHandler);
+  didUpdateArguments() {
+    // resize when arguments changes
+    this.scheduleResize();
+  }
 
-  return () => {
+  willRemove() {
     // clean up
-    element.removeEventListener('input', eventHandler);
-  };
-});
+    this.element.removeEventListener('input', this.scheduleResize);
+  }
+}


### PR DESCRIPTION
Calculating the required height is an expensive operation. `Element.getComputedStyles()`, `Element.scrollHeight` and other features used require the browser to recalculate styles and layout. We should make sure that this is only done once per render.

Such an resize could be triggered by both the input event and a changed argument in the same render. Actually that's very likely as could be seen by this template:

```hbs
<textarea
  value={{this.val}}
  {{autoresize this.val}}
  {{on "input" (action (mut this.val) value="target.value")}}
/>
```

This requires to track if resize has been scheduled even if arguments are changed. This is something which is not good supported by functional modifiers. Therefore the implementation is refactored to use class modifiers instead as part of this change.

Closes #8 