### PR TITLE
readd support for node >= 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "release-it-lerna-changelog": "^2.0.0"
   },
   "engines": {
-    "node": "10.* >= v10.22.1"
+    "node": "10.* >= v10.22.1 || >= 12"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Missed that renovate removed support for node `>= 12` in #61. Seems like a bug. Reported it upstream in https://github.com/renovatebot/renovate/issues/7469.