### PR TITLE
renovate should upgrade major versions only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,5 @@
   "extends": [
     "config:base"
   ],
-  "rangeStrategy": "update-lockfile"
+  "rangeStrategy": "replace"
 }


### PR DESCRIPTION
Renovate should only create pull requests to upgrade dependencies if they aren't covered by current range. This will help to reduce the noise in this repository.

Upgrades allowed by current range are tested already in CI as it uses `--no-lockfile` flag for some scenarios.