### PR TITLE
drop support for Ember < 3.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,8 @@
 #$ browsers:
 #$   - chrome
 #$ emberTryScenarios:
-#$   - scenario: ember-lts-3.12
-#$   - scenario: ember-lts-3.16
-#$   - scenario: ember-lts-3.20
+#$   - scenario: ember-lts-3.24
+#$   - scenario: ember-lts-3.28
 #$   - scenario: ember-release
 #$   - scenario: ember-beta
 #$   - scenario: ember-canary
@@ -173,9 +172,8 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario: [
-          ember-lts-3.12,
-          ember-lts-3.16,
-          ember-lts-3.20,
+          ember-lts-3.24,
+          ember-lts-3.28,
           ember-release,
           ember-beta,
           ember-canary,

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,26 +7,18 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.12',
+        name: 'ember-lts-3.24',
         npm: {
           devDependencies: {
-            'ember-source': '~3.12.0',
+            'ember-source': '~3.24.0',
           },
         },
       },
       {
-        name: 'ember-lts-3.16',
+        name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
-            'ember-source': '~3.16.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5',
+            'ember-source': '~3.28.0',
           },
         },
       },


### PR DESCRIPTION
Dropping support for Ember < 3.24 allows us to upgrade to Ember Modifiers v3: #103 