### PR TITLE
fix min height / width handling

### DIFF
--- a/addon/modifiers/autoresize.js
+++ b/addon/modifiers/autoresize.js
@@ -16,12 +16,16 @@ export default class AutoresizeModifier extends Modifier {
     }
 
     let capitalizeDimension = capitalize(dimension);
+    let computedStyle = window.getComputedStyle(element);
+    let minDimension = computedStyle[`min${capitalizeDimension}`];
 
     // height / width must be calculated independently from height / width previously enforced
-    element.style[dimension] = 'auto';
+    // and calculation should start from min height or width when specified
+    element.style[dimension] = parseInt(minDimension, 10)
+      ? minDimension
+      : 'auto';
 
-    let isBorderBox =
-      window.getComputedStyle(element).boxSizing === 'border-box';
+    let isBorderBox = computedStyle.boxSizing === 'border-box';
     let requiredDimension = element[`scroll${capitalizeDimension}`];
 
     if (isBorderBox) {

--- a/tests/integration/modifiers/autoresize-test.js
+++ b/tests/integration/modifiers/autoresize-test.js
@@ -6,6 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Modifier | autoresize', function (hooks) {
   setupRenderingTest(hooks);
 
+  let shortString = 'abc';
   let longString;
   hooks.beforeEach(function () {
     longString = '';
@@ -40,6 +41,50 @@ module('Integration | Modifier | autoresize', function (hooks) {
 
     await render(hbs`<textarea value={{this.value}} {{autoresize}} />`);
     assert.extendedDom('textarea').doesNotOverflowY();
+  });
+
+  test('it resizes textarea height to fit input min height on initial render with small value', async function (assert) {
+    this.set('value', shortString);
+
+    await render(
+      hbs`<textarea style="padding: 0; min-height: 50px;" value={{this.value}} {{autoresize}} />`
+    );
+    let textarea = find('textarea');
+    assert.strictEqual(textarea.scrollHeight, 50);
+    assert.extendedDom('textarea').doesNotOverflowY();
+  });
+
+  test('it resizes textarea height to fit input min height on initial render with long value', async function (assert) {
+    this.set('value', longString);
+
+    await render(
+      hbs`<textarea style="min-height: 50px;" value={{this.value}} {{autoresize}} />`
+    );
+    let textarea = find('textarea');
+    assert.ok(textarea.scrollHeight > 50);
+    assert.extendedDom('textarea').doesNotOverflowY();
+  });
+
+  test('it resizes textarea width to fit input min width on initial render', async function (assert) {
+    this.set('value', shortString);
+
+    await render(
+      hbs`<textarea style="padding: 0; min-width: 50px;" value={{this.value}} {{autoresize mode="width"}} />`
+    );
+    let textarea = find('textarea');
+    assert.strictEqual(textarea.scrollWidth, 50);
+    assert.extendedDom('textarea').doesNotOverflowX();
+  });
+
+  test('it resizes textarea width to fit input min width on initial render with long value', async function (assert) {
+    this.set('value', longString);
+
+    await render(
+      hbs`<textarea style="min-width: 50px;" value={{this.value}} {{autoresize mode="width"}} />`
+    );
+    let textarea = find('textarea');
+    assert.ok(textarea.scrollWidth > 50);
+    assert.extendedDom('textarea').doesNotOverflowX();
   });
 
   test('it grows textarea height on input to fit value', async function (assert) {


### PR DESCRIPTION
Hello, the addon does not take into account min width or height when specified.
When specifying a min width/height on an autoresized textarea, I expect it to use it as width/height unless the textarea's value requires more width/height.
What do you think about the solution I suggest ?