### PR TITLE
support for node 12 has been dropped already

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Compatibility
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 
 Installation


### PR DESCRIPTION
I missed to update the README when dropping support for node 12 in #123. Shouldn't be an issue as #123 has not been included yet in any release.