### PR TITLE
Drop @ember/string dependency

### DIFF
--- a/addon/modifiers/autoresize.js
+++ b/addon/modifiers/autoresize.js
@@ -1,7 +1,6 @@
 import Modifier from 'ember-modifier';
 import { action } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
-import { capitalize } from '@ember/string';
 import { registerDestructor } from '@ember/destroyable';
 
 function cleanup(instance) {
@@ -23,7 +22,7 @@ export default class AutoresizeModifier extends Modifier {
       element.style.whiteSpace = 'pre';
     }
 
-    let capitalizeDimension = capitalize(dimension);
+    let capitalizeDimension = dimension[0].toUpperCase() + dimension.slice(1);
 
     // height / width must be calculated independently from height / width previously enforced
     element.style[dimension] = 'auto';


### PR DESCRIPTION
Fixes #211

Solution taken from https://stackoverflow.com/questions/1026069/how-do-i-make-the-first-letter-of-a-string-uppercase-in-javascript/33704783#33704783

`@ember/string` uses RegEx to capitalize but I'm not sure it's worth adding that complexity for this simple case.