### PR TITLE
run tests against latest Ember release (v6.2) and prereleases again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,9 @@ jobs:
           - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.12
-          # - ember-release
-          # - ember-beta
-          # - ember-canary
+          - ember-release
+          - ember-beta
+          - ember-canary
           # - embroider-safe
           # - embroider-optimized
 


### PR DESCRIPTION
Those tests had been temporarily disabled in #213. After upgrading some dependencies they seem to pass again.