### PR TITLE
fix broken release-it config after upgrading to @release-it-plugins/lerna-changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "release-it": {
     "plugins": {
-      "release-it-lerna-changelog": {
+      "@release-it-plugins/lerna-changelog": {
         "infile": "CHANGELOG.md"
       }
     },


### PR DESCRIPTION
I missed this in #242.