### PR TITLE
drop support for Ember < v4.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.12
           - ember-release

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Element Modifier that resizes a `<textarea>` accordingly to the input.
 
 ## Compatibility
 
-* Ember.js v4.8 or above
-* Ember CLI v4.8 or above
+* Ember.js v4.12 or above
+* Ember CLI v4.12 or above
 * Node.js v18 or above
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "webpack": "5.98.0"
   },
   "peerDependencies": {
-    "ember-source": ">=4.8.0"
+    "ember-source": ">=4.12.0"
   },
   "engines": {
     "node": "18.* || >= 20"

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -8,14 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-4.8',
-        npm: {
-          devDependencies: {
-            'ember-source': '~5.4.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Drops support for Ember < v4.12. Support for Ember < v4.8 was already dropped in #208 but not released yet.